### PR TITLE
added a simple logic to prevent repetition of data

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { AndrewAccount, AccountDocument } from './account.schema';
 import { AndrewCustomer, CustomerDocument } from '../customer/customer.schema';
 import { ExtractData } from 'src/utils/extractData';
+import { queryDataUtil } from 'src/utils/queryData';
 
 @Injectable()
 export class AccountService {
@@ -18,6 +19,8 @@ export class AccountService {
   ) {}
   async saveAccountInfo(): Promise<void> {
     try {
+      const isPopulated = await queryDataUtil(this.accountModel);
+      if (isPopulated) return;
       const customerData = await this.customerModel.findOne({
         email: this.config.get('USER_EMAIL') || '',
       });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { Inject } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Model } from 'mongoose';
 import { AndrewAuth, AuthDocument } from './auth.schema';
+import { queryDataUtil } from 'src/utils/queryData';
 
 @Injectable()
 export class AuthService {
@@ -16,6 +17,8 @@ export class AuthService {
 
   async extractAndSaveAuthInfo(): Promise<any> {
     try {
+      const isPopulated = await queryDataUtil(this.authModel);
+      if (isPopulated) return;
       const authInfo = new this.authModel({
         email: this.config.get('USER_EMAIL') || '',
         password: this.config.get('USER_PASSWORD') || '',

--- a/src/customer/customer.service.ts
+++ b/src/customer/customer.service.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { AndrewCustomer, CustomerDocument } from './customer.schema';
 import { AndrewAuth, AuthDocument } from '../auth/auth.schema';
 import { ExtractData } from 'src/utils/extractData';
+import { queryDataUtil } from 'src/utils/queryData';
 
 @Injectable()
 export class CustomerService {
@@ -19,6 +20,8 @@ export class CustomerService {
   ) {}
   async saveCustomerInfo(): Promise<any> {
     try {
+      const isPopulated = await queryDataUtil(this.customerModel);
+      if (isPopulated) return;
       const authData = await this.authModel.findOne({
         email: this.config.get('USER_EMAIL') || '',
       });

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { AndrewTransaction, TransactionDocument } from './transaction.schema';
 import { AndrewAccount, AccountDocument } from '../account/account.schema';
 import { ExtractData } from 'src/utils/extractData';
+import { queryDataUtil } from 'src/utils/queryData';
 
 @Injectable()
 export class TransactionService {
@@ -19,6 +20,8 @@ export class TransactionService {
   ) {}
   async saveTransactionInfo() {
     try {
+      const isPopulated = await queryDataUtil(this.transactionModel);
+      if (isPopulated) return;
       const authPayload = {
         emailAddress: this.config.get('USER_EMAIL') || '',
         password: this.config.get('USER_PASSWORD') || '',

--- a/src/utils/queryData.ts
+++ b/src/utils/queryData.ts
@@ -1,0 +1,11 @@
+import { Model } from 'mongoose';
+
+// checks if the collection is empty. If already populated, there is no need scraping the data again and inserting into the db
+export const queryDataUtil = async (dbModel: Model<any>): Promise<number> => {
+  try {
+    const data = await dbModel.find().limit(1);
+    return data.length;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
**What does this PR do?**
This PR adds a logic that prevents duplication of data. When the collection is empty, the API scrapes data & populates the DB. Subsequent API calls will not scrape any data or hit the DB.

**Consideration**
There's a catch though. This solution is with the assumption that the authentication details do not change i.e the same user hitting the endpoint multiple times