### PR TITLE
remove the heasless option when Puppeteer launches

### DIFF
--- a/src/utils/extractData.ts
+++ b/src/utils/extractData.ts
@@ -211,7 +211,7 @@ export class ExtractData {
   > {
     let browser, page;
     try {
-      browser = await Puppeteer.launch({ headless: false });
+      browser = await Puppeteer.launch();
       page = await this.automateLogin(browser, constants.URL, authPayload);
       const viewAccountBtns: Array<ElementHandle> = await page.$x(
         "//a[contains(text(), 'View Account')]",


### PR DESCRIPTION
**What does this PR do?**
This PR removes the headless option when Puppeteer launches. I added the option when I wanted to see graphically how Puppeteer interacts with the web page and I forgot to remove it before I pushed & merged. Setting this option to false might have issues in the production environment which is why I'm removing it