### PR TITLE
show the chromium browser during development but hide in production

### DIFF
--- a/src/utils/extractData.ts
+++ b/src/utils/extractData.ts
@@ -35,7 +35,9 @@ export class ExtractData {
     },
   ): Promise<[Page, Browser]> {
     try {
-      const browser = await Puppeteer.launch({ headless: false });
+      const browser = await Puppeteer.launch({
+        headless: process.env.NODE_ENV === 'production' ? true : false,
+      });
       const page = await browser?.newPage();
       page?.on('dialog', async (dialog: { accept: () => void }) => {
         await dialog.accept();


### PR DESCRIPTION
**What does this PR do?**
This PR displays the chromium browser based on the NODE_ENV variable. For debugging purposes, the chromium browser is visible and you can see how Puppeteer interacts with the browser during development.